### PR TITLE
textpic: fixed missing heading when setting above image

### DIFF
--- a/Resources/Private/Templates/Content/Textpic.html
+++ b/Resources/Private/Templates/Content/Textpic.html
@@ -8,6 +8,9 @@
 	<f:then>
 		<f:if condition="{data.bodytext} || {data.header}">
 			<f:then>
+				<f:if condition="!{gallery.headerBeside}">
+					<f:render partial="Header/All" arguments="{_all}" />
+				</f:if>
 				<f:render partial="TextWithImage" arguments="{_all}" />
 			</f:then>
 			<f:else>


### PR DESCRIPTION
For TextPic content the heading was missing when using Header Position: "Above the image"