### PR TITLE
BUGFIX: Move typo3 version variable in outer scope

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -70,6 +70,9 @@ call_user_func(function () {
 	 */
 	$extconf = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class)->get('t3sbootstrap');
 
+	$typo3Version = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
+	$version = $typo3Version->getMajorVersion();
+
 	/***************
 	 * Other Extensions
 	 */
@@ -79,9 +82,6 @@ call_user_func(function () {
 		/***************
 		 * plugin content consent
 		 */
-
-		$typo3Version = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Information\Typo3Version::class);
-		$version = (int)$typo3Version->getVersion();
 
 		if ($version == 10) {
 


### PR DESCRIPTION
The reimplementation of the tasks (requested in #57 ) introduced a bug.
The typo3 version variable for the extra check was nested inside an if-scope, which is only loaded if`typoscript_rendering` is loaded.

- Replace getVersion() with getMajorVersion().
- Move $version outside if-scope, because it is used later in the function.
   - Fixes the bug introduced in 5aca9cb496080fb0b5e16698ecdfe96864e2710f.

Tested on Typo3 9.5.21 and PHP 7.2.10.