### PR TITLE
[BUGFIX] ID corrected

### DIFF
--- a/Resources/Private/Backend/Partials/Version9/Accordion.html
+++ b/Resources/Private/Backend/Partials/Version9/Accordion.html
@@ -3,7 +3,7 @@
 	<div class="panel panel-default">
 		<div class="panel-heading" role="tab" id="generalNavbar">
 			<h4 class="panel-title">
-				<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseMeta" aria-expanded="true" aria-controls="collapseGeneral">
+				<a role="button" data-toggle="collapse" data-parent="#accordion" href="#collapseGeneral" aria-expanded="true" aria-controls="collapseGeneral">
 					General Settings
 				</a>
 			</h4>


### PR DESCRIPTION
Fixed a bug in TYPO3 9 that caused the new menu item in the Accordion not to be opened