### PR TITLE
[BUGFIX & FEATURE] Links with phone numbers & Full integration of FA5Pro

### DIFF
--- a/Configuration/TSConfig/CKEditor.tsconfig
+++ b/Configuration/TSConfig/CKEditor.tsconfig
@@ -46,9 +46,9 @@ RTE {
 				rel =
 			}
 
-			tel {
+			telephone {
 				class = phone-link
-				type = tel
+				type = telephone
 				titleText = Call us
 				target = _blank
 				image =
@@ -71,7 +71,7 @@ RTE {
 			mail.properties {
 				class.default =
 			}
-			tel.properties {
+			telephone.properties {
 				class.default =
 			}
 			properties.class.allowedClasses = phone-link, external-link, internal-link, email-link, download-link, btn, btn btn-primary, btn btn-secondary, btn btn-success, btn btn-danger, btn btn-warning, btn btn-info, btn btn-light, btn btn-dark, js-scroll-trigger

--- a/Resources/Public/Contrib/Fontawesome/css/fontawesomeLink.css
+++ b/Resources/Public/Contrib/Fontawesome/css/fontawesomeLink.css
@@ -10,7 +10,8 @@
 .internal-link::before,
 .external-link::before,
 .download-link::before,
-.email-link::before {
+.email-link::before,
+.phone-link::before {
 	margin-right: 0.5em;
 	display: inline-block;
 	font-style: normal;
@@ -31,5 +32,6 @@
 .email-link::before {
 	font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f0e0";
 }
-
-
+.phone-link::before {
+	font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f095";
+}

--- a/Resources/Public/Contrib/Fontawesome/css/fontawesomeMinLink.css
+++ b/Resources/Public/Contrib/Fontawesome/css/fontawesomeMinLink.css
@@ -39,7 +39,8 @@
 .internal-link::before,
 .external-link::before,
 .download-link::before,
-.email-link::before {
+.email-link::before,
+.phone-link::before {
 	margin-right: 0.5em;
 	display: inline-block;
 	font-style: normal;
@@ -59,6 +60,9 @@
 }
 .email-link::before {
 	font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f0e0";
+}
+.phone-link::before {
+	font-family: "Font Awesome 5 Free"; font-weight: 900; content: "\f095";
 }
 
 

--- a/Resources/Public/Contrib/Fontawesome/css/fontawesomeProLink.css
+++ b/Resources/Public/Contrib/Fontawesome/css/fontawesomeProLink.css
@@ -1,4 +1,20 @@
 @font-face {
+	font-family: 'Font Awesome 5 Pro';
+	font-style: normal;
+	font-weight: 300;
+	src: url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.eot");
+	src: url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.eot?#iefix") format("embedded-opentype"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.woff2") format("woff2"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.woff") format("woff"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.ttf") format("truetype"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-light-300.svg#fontawesome") format("svg");
+	font-display: swap; }
+
+@font-face {
+	font-family: 'Font Awesome 5 Pro';
+	font-style: normal;
+	font-weight: 400;
+	src: url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.eot");
+	src: url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.eot?#iefix") format("embedded-opentype"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.woff2") format("woff2"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.woff") format("woff"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.ttf") format("truetype"), url("../../../../../../../../../fileadmin/T3SB/FA5Pro/webfonts/fa-regular-400.svg#fontawesome") format("svg");
+	font-display: swap; }
+
+@font-face {
   font-family: 'Font Awesome 5 Pro';
   font-style: normal;
   font-weight: 900;

--- a/Resources/Public/Contrib/Fontawesome/css/fontawesomeProLink.css
+++ b/Resources/Public/Contrib/Fontawesome/css/fontawesomeProLink.css
@@ -10,7 +10,8 @@
 .internal-link::before,
 .external-link::before,
 .download-link::before,
-.email-link::before {
+.email-link::before,
+.phone-link::before {
 	margin-right: 0.5em;
 	display: inline-block;
 	font-style: normal;
@@ -31,4 +32,6 @@
 .email-link::before {
 	font-family: "Font Awesome 5 Pro"; font-weight: 900; content: "\f0e0";
 }
-
+.phone-link::before {
+	font-family: "Font Awesome 5 Pro"; font-weight: 900; content: "\f095";
+}


### PR DESCRIPTION
- [BUGFIX] Make the CSS class `.phone-links` for phone numbers selectable or available:
I have been dealing with this a lot in the last few days because I had to make this link available in a project. Found error and now I want to share the solution.
- [FEATURE] Added style for `.phone-links`
- [FEATURE] Full integration of FA5Pro:
Adding the Regular and Light font to make it usable.
The [Dokumentation](https://www.t3sbootstrap.de/dokumentation/snippets/extend-t3sbootstrap/font-awesome-pro) could be expanded to include the following:

**Custom FA5Pro Style:**
Als Standard wird bei der Integration von FA5Pro der Solid-Style verwendet. Dies kann im eigenem CSS durch folgendes angepasst werden:

FA5Pro Regular:
```CSS
.internal-link::before,
.external-link::before,
.download-link::before,
.email-link::before,
.phone-link::before {
  font-weight: 400!important;
}
```

FA5Pro Light:
```CSS
.internal-link::before,
.external-link::before,
.download-link::before,
.email-link::before,
.phone-link::before {
  font-weight: 300!important;
}
```