### PR TITLE
Fix - megamenu is not removed in mobile

### DIFF
--- a/Resources/Private/Partials/Page/Navbar/Assets.html
+++ b/Resources/Private/Partials/Page/Navbar/Assets.html
@@ -55,7 +55,7 @@
 	}, true);
 </f:asset.script>
 </f:if>
-<f:if condition="{settings.config.navbarMegamenu} && {data.tx_t3sbootstrap_megamenu}">
+<f:if condition="{settings.config.navbarMegamenu}">
 <f:asset.script identifier="vanilla_navbarmegamenuJs">
 	// Navbar mega-menu - Navbar/Assets.html
 	var megaDropdown = document.querySelectorAll('.mega-dropdown'),


### PR DESCRIPTION
This fixes the problem that megamenu content does not get removed when the menu is in mobile mode.  
As is understand it `data.tx_t3sbootstrap_megamenu` is only set on specific pages, so ost of the time this does not work,