### PR TITLE
Fehlendes Alt-Attribut in Image.html

### DIFF
--- a/Resources/Private/Partials/Content/Media/Rendering/Image.html
+++ b/Resources/Private/Partials/Content/Media/Rendering/Image.html
@@ -9,7 +9,7 @@
 
 <f:if condition="{addmedia.origImg}">
 	<f:then>
-		<f:image class="img-fluid{extraImgClass}" src="fileadmin/{file.identifier}" />
+		<f:image class="img-fluid{extraImgClass}" alt="{altText}" src="fileadmin/{file.identifier}" />
 	</f:then>
 	<f:else>
 		<f:if condition="{file.properties.tx_t3sbootstrap_imgtag}">


### PR DESCRIPTION
Fehlendes Alt-Attribut, wenn man Original Image nutzt.

