### PR TITLE
[FEATURE] allow override of bootstrap.extconf.webp typoscript constants

### DIFF
--- a/Classes/Utility/ResponsiveImagesUtility.php
+++ b/Classes/Utility/ResponsiveImagesUtility.php
@@ -7,6 +7,7 @@ use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Resource\FileInterface;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\CropVariantCollection;
 use TYPO3\CMS\Core\Imaging\ImageManipulation\Area;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 use TYPO3Fluid\Fluid\Core\ViewHelper\TagBuilder;
 use TYPO3\CMS\Extbase\Service\ImageService;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -28,6 +29,13 @@ class ResponsiveImagesUtility implements SingletonInterface
 	protected $imageService;
 
 	/**
+	 * Configuration Manager
+	 *
+	 * @var ConfigurationManager
+	 */
+	protected $configurationManager;
+
+	/**
 	 * Default media breakpoint configuration
 	 *
 	 * @var array
@@ -42,9 +50,10 @@ class ResponsiveImagesUtility implements SingletonInterface
 	/**
 	 * @param ImageService $imageService
 	 */
-	public function __construct(ImageService $imageService)
+	public function __construct(ImageService $imageService, ConfigurationManager $configurationManager)
 	{
 		 $this->imageService = $imageService;
+		 $this->configurationManager = $configurationManager;
 	}
 
 
@@ -85,7 +94,8 @@ class ResponsiveImagesUtility implements SingletonInterface
 		$tag = $tag ?: GeneralUtility::makeInstance(TagBuilder::class, 'picture');
 		$fallbackTag = $fallbackTag ?: GeneralUtility::makeInstance(TagBuilder::class, 'img');
 
-		$webpIsLoaded = ExtensionManagementUtility::isLoaded('webp');
+		$settings = $this->configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+		$webpIsLoaded = (bool)$settings['page.']['10.']['settings.']['webp'];
 
 		// Deal with file formats that can't be cropped separately
 		if ($this->hasIgnoredFileExtension($originalImage, $ignoreFileExtensions)) {

--- a/Classes/ViewHelpers/MediaViewHelper.php
+++ b/Classes/ViewHelpers/MediaViewHelper.php
@@ -9,6 +9,7 @@ use T3SBS\T3sbootstrap\Utility\ResponsiveImagesUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Extbase\Configuration\ConfigurationManager;
 
 /*
  * This file is part of the TYPO3 extension t3sbootstrap.
@@ -26,11 +27,24 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
 	protected $responsiveImagesUtility;
 
 	/**
+	 * @var ConfigurationManager
+	 */
+	protected $configurationManager;
+
+	/**
 	 * @param ResponsiveImagesUtility $responsiveImagesUtility
 	 */
 	public function injectResponsiveImagesUtility(ResponsiveImagesUtility $responsiveImagesUtility)
 	{
 		$this->responsiveImagesUtility = $responsiveImagesUtility;
+	}
+
+	/**
+	 * @param ConfigurationManager $configurationManager
+	 */
+	public function injectConfigurationManager(ConfigurationManager $configurationManager)
+	{
+		$this->configurationManager = $configurationManager;
 	}
 
 	/**
@@ -258,7 +272,8 @@ class MediaViewHelper extends \TYPO3\CMS\Fluid\ViewHelpers\MediaViewHelper
 		 $imageService = $this->getImageService();
 		 $processedImage = $imageService->applyProcessingInstructions($image, $processingInstructions);
 
-		$webpIsLoaded = ExtensionManagementUtility::isLoaded('webp');
+		$settings = $this->configurationManager->getConfiguration(\TYPO3\CMS\Extbase\Configuration\ConfigurationManagerInterface::CONFIGURATION_TYPE_FULL_TYPOSCRIPT);
+		$webpIsLoaded = (bool)$settings['page.']['10.']['settings.']['webp'];
 		if ( $webpIsLoaded ) {
 			$webpIdentifier = $processedImage->getIdentifier().'.webp';
 			$processedImage->setIdentifier($webpIdentifier);


### PR DESCRIPTION
We want to use the default EXT:webp .htaccess Configuration and do not want to generate image tags with .webp in the src.

With this change we are able to set the `bootstrap.extconf.webp` to `0` and completely disable the webp behavior of t3sbootstrap.