### PR TITLE
Fix argument type exception in ConfigProcessor

### DIFF
--- a/Classes/DataProcessing/ConfigProcessor.php
+++ b/Classes/DataProcessing/ConfigProcessor.php
@@ -630,13 +630,13 @@ class ConfigProcessor implements DataProcessorInterface
 		$processedData['config']['expandedcontentTop']['slide'] = $processedRecordVariables['expandedcontentSlidetop'];
 		$processedData['config']['expandedcontentTop']['container'] = $processedRecordVariables['expandedcontentContainertop'];
 		$processedData['config']['expandedcontentTop']['containerposition'] = $processedRecordVariables['expandedcontentContainerpositiontop'];
-		$processedData['config']['expandedcontentTop']['class'] = trim($processedRecordVariables['expandedcontentClasstop']);
+		$processedData['config']['expandedcontentTop']['class'] = trim($processedRecordVariables['expandedcontentClasstop'] ?? '');
 
 		$processedData['config']['expandedcontentBottom']['enable'] = $processedRecordVariables['expandedcontentEnablebottom'];
 		$processedData['config']['expandedcontentBottom']['slide'] = $processedRecordVariables['expandedcontentSlidebottom'];
 		$processedData['config']['expandedcontentBottom']['container'] = $processedRecordVariables['expandedcontentContainerbottom'];
 		$processedData['config']['expandedcontentBottom']['containerposition'] = $processedRecordVariables['expandedcontentContainerpositionbottom'];
-		$processedData['config']['expandedcontentBottom']['class'] = trim($processedRecordVariables['expandedcontentClassbottom']);
+		$processedData['config']['expandedcontentBottom']['class'] = trim($processedRecordVariables['expandedcontentClassbottom'] ?? '');
 
 		return $processedData;
 	}


### PR DESCRIPTION
Fixes `Exception: trim(): Argument #1 ($string) must be of type string, null given in Classes/DataProcessing/ConfigProcessor.php` 